### PR TITLE
Remove unused & deprecated 'crypto' module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "charwise": "^3.0.1",
     "concat-stream": "^1.6.2",
-    "crypto": "^1.0.1",
     "dat-encoding": "^5.0.1",
     "dat-swarm-defaults": "^1.0.1",
     "discovery-swarm": "^5.1.2",


### PR DESCRIPTION
Super minor change, but installing cabal shows me the following warning right now:

```
npm WARN deprecated crypto@1.0.1: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
```

Since the crypto module isn't even used anywhere in this module, this should be a safe change. All tests still pass.