### PR TITLE
Use Major Versioned swarm key

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var timestamp = require('monotonic-timestamp')
 var createChannelView = require('./views/channels')
 var createMessagesView = require('./views/messages')
 var createUsersView = require('./views/users')
+var version = require("./package.json").version
 
 module.exports = Cabal
 
@@ -39,6 +40,8 @@ function Cabal (storage, key, opts) {
   }
 
   this.key = key || null
+  var majorVersion = version.split(".")[0]
+  this.swarmKey = `v${majorVersion}-${this.key}`
   this.db = kappa(storage, { valueEncoding: json })
 
   // Create (if needed) and open local write feed

--- a/swarm.js
+++ b/swarm.js
@@ -3,7 +3,7 @@ var swarmDefaults = require('dat-swarm-defaults')
 
 module.exports = function (cabal) {
   var swarm = discovery(swarmDefaults())
-  swarm.join(cabal.key.toString('hex'))
+  swarm.join(cabal.swarmKey.toString('hex'))
   swarm.on('connection', function (conn, info) {
     var remoteKey
 


### PR DESCRIPTION
# background

## problem
we have a bunch of problems in the transition from the hyperdb backend to the kappa-core/multifeed backend. nobody really knows what happens, but public cabals keep dying as a result.

in the long-term we obviously want to make the database resilient towards errors of all kinds, and not kill cabals, but in the short term we need it to work otherwise we'll burnout.

## solution
so thinking about it for a moment, i realized we could use the **major version** of the code and prepend that to the cabal key and call this new thing the **swarm key**. 

this makes sense since major versions signal breaking changes, so clients shouldn't be expected to handle the new behaviour anyway. addtionally, the key we swarm on (via discovery swarm) to communicate between nodes in a cabal, is separate from the key used in the database.

this is kind of a wip that i threw together in a few minutes so we need to actually try that it works, i might've also missed something in my enthusiastic outburst ahaha