### PR TITLE
[RFC) introduce protocol version

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,10 @@ var createChannelView = require('./views/channels')
 var createMessagesView = require('./views/messages')
 var createUsersView = require('./views/users')
 
+var PROTOCOL_VERSION = "1.0.0"
+
 module.exports = Cabal
+module.exports.protocolVersion = PROTOCOL_VERSION
 
 /**
  * Create a new cabal. This is the object handling all
@@ -63,6 +66,10 @@ function Cabal (storage, key, opts) {
 }
 
 inherits(Cabal, events.EventEmitter)
+Cabal.prototype.getProtocolVersion = function (cb) {
+  if (!cb) cb = noop
+  cb(PROTOCOL_VERSION)
+}
 
 /**
  * Get information about a user that they've volunteered about themselves.


### PR DESCRIPTION
## Background
We've come into a bunch of situations where old clients have seemingly caused a lot of bad shit to happen when making breaking changes in the protocol.

Sometimes the bad behaviour have been bugs that surfaced due to something else, but it has been hard to reason about issues since there was always the explanation that `well maybe it's the old clients fault`. 

## INTRODUCING PROTOCOL VERSIONS

Basically we introduce a protocol version that allows us to exclude old clients as a cause for bad behaviour, because they simply will not use the same database and thus cannot forward any bad data.


It's exposed in `index.js` as `module.exports.protocolVersion` and on every cabal as `cabal.getProtocolVersion(cb)`

In the [terminal client](https://github.com/cabal-club/cabal/blob/multi-cabal-protocol-version/cli.js#L15) we use it to version all of the databases (well, except for the one created with `--db` but that's in the pipeline to be changed). 

This means all new cabal related files will live in `~/.cabal/<protocolVersion>/` with the `kappa-core` databases in `~/.cabal/<protocolVersion>/archives/<cabalKey>`

## Discussion
Currently the protocol version is 1.0.0, just like [`multifeed`](https://github.com/noffle/multifeed/blob/master/index.js#L12), but i don't think it makes sense for cabal. 

My reasoning behind that opinion is that any change to the protocol version will effectively be a breaking change (since we have a new database location) and so the [semver](https://semver.org/) notation is misleading. 

I would love some input on this part in particular.


~cblgh
