### PR TITLE
Database version Rename

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,10 @@ var createMessagesView = require('./views/messages')
 var createTopicsView = require('./views/topics')
 var createUsersView = require('./views/users')
 
-var PROTOCOL_VERSION = '1.0.0'
+var DATABASE_VERSION = 1
 
 module.exports = Cabal
-module.exports.protocolVersion = PROTOCOL_VERSION
+module.exports.databaseVersion = DATABASE_VERSION
 
 /**
  * Create a new cabal. This is the object handling all
@@ -66,9 +66,9 @@ function Cabal (storage, key, opts) {
 }
 
 inherits(Cabal, events.EventEmitter)
-Cabal.prototype.getProtocolVersion = function (cb) {
+Cabal.prototype.getDatabaseVersion = function (cb) {
   if (!cb) cb = noop
-  process.nextTick(cb, PROTOCOL_VERSION)
+  process.nextTick(cb, DATABASE_VERSION)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cabal-core",
-  "version": "3.1.0",
+  "version": "3.0.4",
   "description": " p2p db functions for chat ",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cabal-core",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": " p2p db functions for chat ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
i renamed protocol version to database version and used an int to represent it instead as it doesn't make sense to have minor & patch on something like this.

lmk what else we can do here before we merge into master

this will be required for [cabal-cli's multi cabal pr](https://github.com/cabal-club/cabal/pull/89)