### PR TITLE
Send maxFeeds option on kappa-core replicate to actually get through to hypercore-protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,9 +38,9 @@ function Cabal (storage, key, opts) {
     }
   }
 
+  this.maxFeeds = opts.maxFeeds
   this.key = key || null
   this.db = kappa(storage, {
-    maxFeeds: opts.maxFeeds,
     valueEncoding: json
   })
 
@@ -158,7 +158,10 @@ Cabal.prototype.getLocalKey = function (cb) {
  * Replication stream for the mesh.
  */
 Cabal.prototype.replicate = function () {
-  return this.db.replicate({ live: true })
+  return this.db.replicate({
+    live: true,
+    maxFeeds: this.maxFeeds
+  })
 }
 
 Cabal.prototype._addConnection = function (key) {


### PR DESCRIPTION
I incorrectly set the maxFeeds option on the kappa-core constructor. To actually get through to hypercore-protocol it should be set on the replicate function.

Fixes https://github.com/cabal-club/cabal/issues/106

Thanks to @karissa for pointing me in the right direction!