### PR TITLE
opts.db to pass durable storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ string (filepath to directory on disk) or an instance of
 
 If this is a new database, `key` can be omitted and will be generated.
 
+You can pass `opts.db` as a levelup or leveldown instance to use persistent
+storage for indexing instead of using memory. For example:
+
+``` js
+var level = require('level')
+var cabal = Cabal(storage, key, { db: level('/tmp/bot.db') })
+```
+
 ### cabal.getLocalKey(cb)
 
 Returns the local user's key (as a hex string).
@@ -26,6 +34,10 @@ Returns the local user's key (as a hex string).
 
 Creates a new, live replication stream. This duplex stream can be piped into any
 transport expressed as a node stream (tcp, websockets, udp, utp, etc).
+
+### cabal.ready(cb)
+
+Call `cb()` when the underlying indexes are caught up.
 
 ### Channels
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "randombytes": "^2.0.6",
     "read-only-stream": "^2.0.0",
     "strftime": "^0.10.0",
+    "subleveldown": "^4.0.0",
     "through2": "^3.0.1",
     "thunky": "^1.0.3",
     "xtend": "^4.0.1"

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ var pump = require('pump')
 
 test('create a cabal + channel', function (t) {
   var cabal = Cabal(ram)
-  cabal.db.ready(function () {
+  cabal.ready(function () {
     var msg = {
       type: 'chat/text',
       content: {
@@ -38,7 +38,7 @@ test('reading back multiple messages', function (t) {
 
   var pending = 3
 
-  cabal.db.ready(function () {
+  cabal.ready(function () {
     cabal.publish({
       type: 'chat/text',
       content: {
@@ -107,7 +107,7 @@ test('listening for live messages', function (t) {
     if (++count === 3) t.end()
   })
 
-  cabal.db.ready(function () {
+  cabal.ready(function () {
     cabal.publish({
       type: 'chat/text',
       content: {
@@ -137,7 +137,7 @@ test('local replication', function (t) {
 
   function create (id, cb) {
     var cabal = Cabal(ram)
-    cabal.db.ready(function () {
+    cabal.ready(function () {
       var msg = {
         type: 'chat/text',
         content: {
@@ -188,7 +188,7 @@ test('swarm network replication', function (t) {
 
   function create (id, cb) {
     var cabal = Cabal(ram, 'fake')
-    cabal.db.ready(function () {
+    cabal.ready(function () {
       var msg = {
         type: 'chat/text',
         content: {


### PR DESCRIPTION
This patch makes it possible to use durable storage from a levelup or leveldown instance as `opts.db` instead of always using memdb.