### PR TITLE
set max listeners for event emitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function Cabal (storage, key, opts) {
   if (!(this instanceof Cabal)) return new Cabal(storage, key, opts)
   if (!opts) opts = {}
   events.EventEmitter.call(this)
+  this.setMaxListeners(Infinity)
 
   var json = {
     encode: function (obj) {


### PR DESCRIPTION
i was working on cabal client when i noticed the following

![image](https://user-images.githubusercontent.com/3862362/60384736-e1b98000-9a81-11e9-9cba-e3b64619ee54.png)

1. cabal-core doesn't set its max listeners limit
1. levelup sets it to infinity

so i figured we would do the same [thing](https://github.com/Level/levelup/blob/master/lib/levelup.js#L34-L35) in the hopes of it solving https://github.com/cabal-club/cabal-cli/issues/110

tagging a few reviewers to make sure this isn't really dumb