### PR TITLE
add dns-discovery server: eight45.net

### DIFF
--- a/swarm.js
+++ b/swarm.js
@@ -1,8 +1,10 @@
 var pump = require('pump')
 var discovery = require('discovery-swarm')
-var swarmDefaults = require('dat-swarm-defaults')
+var swarmDefaults = require('dat-swarm-defaults')()
 var debug = require('debug')('cabal')
 var crypto = require('hypercore-crypto')
+
+swarmDefaults.dns.server.push('eight45.net:9090')
 
 // If a peer triggers one of these, don't just throttle them: block them for
 // the rest of the session.
@@ -24,7 +26,7 @@ module.exports = function (cabal, opts, cb) {
   cabal.getLocalKey(function (err, key) {
     if (err) return cb(err)
 
-    var swarm = discovery(Object.assign({}, swarmDefaults(), { id: Buffer.from(key, 'hex') }))
+    var swarm = discovery(Object.assign({}, swarmDefaults, { id: Buffer.from(key, 'hex') }))
     var cabalKey = Buffer.isBuffer(cabal.key) ? cabal.key : Buffer.from(cabal.key, 'hex')
     var swarmKey = crypto.discoveryKey(cabalKey)
     swarm.join(swarmKey.toString('hex'))

--- a/swarm.js
+++ b/swarm.js
@@ -6,7 +6,8 @@ var crypto = require('hypercore-crypto')
 
 var cabalDiscoveryServers = [
   'eight45.net:9090',
-  'dnsdiscovery.four.parts:9090'
+  'dnsdiscovery.four.parts:9090',
+  'cblgh.org:9090'
 ]
 Array.prototype.push.apply(swarmDefaults.dns.server, cabalDiscoveryServers)
 

--- a/swarm.js
+++ b/swarm.js
@@ -4,7 +4,11 @@ var swarmDefaults = require('dat-swarm-defaults')()
 var debug = require('debug')('cabal')
 var crypto = require('hypercore-crypto')
 
-swarmDefaults.dns.server.push('eight45.net:9090')
+var cabalDiscoveryServers = [
+  'eight45.net:9090',
+  'dnsdiscovery.four.parts:9090'
+]
+Array.prototype.push.apply(swarmDefaults.dns.server, cabalDiscoveryServers)
 
 // If a peer triggers one of these, don't just throttle them: block them for
 // the rest of the session.


### PR DESCRIPTION
Trying to see if I can increase cabal's reliability by hosting an additional
dns-discovery server.

If you'd like to host one too, run these commands on your VPS / machine with a public IP:

```
npm i -g dns-discovery
dns-discovery listen --port=9090 --ttl=30
```

and send a PR or reply here.