### PR TITLE
moderation.banInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,11 @@ banned users.
 
 Return a readable objectMode stream of bans for `channel`.
 
-Each ban is an object with either a `key` or `ip` property.
+Each ban is an object with:
+
+* `ban.type` - `'key'` or `'ip'`
+* `ban.id` - the target of the ban: a key or ip address string
+* `ban.key` - the `'feed@seq'` string you can pass to `banInfo()`
 
 To list cabal-wide bans use the special channel `@`.
 
@@ -122,6 +126,13 @@ To list cabal-wide bans use the special channel `@`.
 Determine whether a user identified by `ip` and/or `key` is banned on `channel`
 or cabal-wide as `cb(err, banned)` for a boolean `banned`. If `channel` is
 omitted, only check cabal-wide.
+
+#### cabal.moderation.banInfo('feed@seq', cb)
+
+Load the original ban message as `cb(err, msg)`.
+
+You can check `msg.content` for things like a `reason` field or you can check
+`msg.timestamp`.
 
 ### Publishing
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "kappa-core": "^6.0.0",
     "kappa-view-level": "^2.0.1",
     "level-mem": "^5.0.1",
-    "materialized-group-auth": "^1.1.1",
+    "materialized-group-auth": "^1.2.0",
     "monotonic-timestamp": "0.0.9",
     "once": "^1.4.0",
     "pump": "^3.0.0",

--- a/test/mod.js
+++ b/test/mod.js
@@ -10,9 +10,11 @@ test('ban a user by key', function (t) {
 
   var addr = randomBytes(32).toString('hex')
   var cabal0 = Cabal(ram, 'cabal://' + addr)
+  var key0 = null
   cabal0.ready(function () {
     cabal0.getLocalKey(function (err, key) {
       t.error(err)
+      key0 = key
       var cabal1 = Cabal(ram, 'cabal://' + addr, { modKey: key })
       var cabal2 = Cabal(ram, 'cabal://' + addr, { modKey: key })
       var pending = 3
@@ -36,7 +38,9 @@ test('ban a user by key', function (t) {
         t.error(err)
         collect(cabal2.moderation.listBans('@'), function (err, bans) {
           t.error(err)
-          t.deepEqual(bans, [{ key: key1 }])
+          t.deepEqual(bans, [
+            { type: 'key', id: key1, key: key0+'@0' }
+          ])
         })
         cabal2.moderation.isBanned({ key: key1 }, function (err, banned) {
           t.error(err)
@@ -99,9 +103,11 @@ test('delegated moderator ban a user by key', function (t) {
 
   var addr = randomBytes(32).toString('hex')
   var cabal0 = Cabal(ram, 'cabal://' + addr)
+  var key0 = null
   cabal0.ready(function () {
     cabal0.getLocalKey(function (err, key) {
       t.error(err)
+      key0 = key
       var cabal1 = Cabal(ram, addr, { modKey: key })
       var cabal2 = Cabal(ram, addr, { modKey: key })
       var pending = 3
@@ -131,7 +137,9 @@ test('delegated moderator ban a user by key', function (t) {
           t.error(err)
           collect(cabal0.moderation.listBans('@'), function (err, bans) {
             t.error(err)
-            t.deepEqual(bans, [{ key: key1 }])
+            t.deepEqual(bans, [
+              { type: 'key', id: key1, key: key2 + '@0' }
+            ])
           })
           collect(cabal1.moderation.listBans('@'), function (err, bans) {
             t.error(err)
@@ -139,7 +147,9 @@ test('delegated moderator ban a user by key', function (t) {
           })
           collect(cabal2.moderation.listBans('@'), function (err, bans) {
             t.error(err)
-            t.deepEqual(bans, [{ key: key1 }])
+            t.deepEqual(bans, [
+              { type: 'key', id: key1, key: key2 + '@0' }
+            ])
           })
           cabal0.moderation.isBanned({ key: key1 }, function (err, banned) {
             t.error(err)
@@ -213,6 +223,59 @@ test('different mod keys have different views', function (t) {
     })
   }
 })
+
+test('ban a user by key with a reason', function (t) {
+  t.plan(10)
+
+  var addr = randomBytes(32).toString('hex')
+  var cabal0 = Cabal(ram, 'cabal://' + addr)
+  var key0 = null
+  cabal0.ready(function () {
+    cabal0.getLocalKey(function (err, key) {
+      key0 = key
+      t.error(err)
+      var cabal1 = Cabal(ram, 'cabal://' + addr, { modKey: key })
+      var cabal2 = Cabal(ram, 'cabal://' + addr, { modKey: key })
+      var pending = 3
+      cabal1.ready(function () {
+        if (--pending === 0) ready(cabal0, cabal1, cabal2)
+      })
+      cabal2.ready(function () {
+        if (--pending === 0) ready(cabal0, cabal1, cabal2)
+      })
+      if (--pending === 0) ready(cabal0, cabal1, cabal2)
+    })
+  })
+  function ready (cabal0, cabal1, cabal2) {
+    cabal1.getLocalKey(function (err, key1) {
+      t.error(err)
+      cabal0.publish({
+        type: 'ban/add',
+        content: { key: key1, reason: 'spammer' }
+      })
+      sync([cabal0,cabal1,cabal2], function (err) {
+        t.error(err)
+        collect(cabal2.moderation.listBans('@'), function (err, bans) {
+          t.error(err)
+          t.deepEqual(bans, [{ type: 'key', id: key1, key: key0+'@0' }])
+          cabal2.moderation.banInfo(bans[0].key, function (err, info) {
+            t.error(err)
+            t.deepEqual(info.content, {
+              key: key1,
+              reason: 'spammer'
+            })
+            t.ok(info.timestamp)
+          })
+        })
+        cabal2.moderation.isBanned({ key: key1, seq: 0 }, function (err, banned) {
+          t.error(err)
+          t.ok(banned)
+        })
+      })
+    })
+  }
+})
+
 
 function sync (cabals, cb) {
   cb = cb || function(){}


### PR DESCRIPTION
This patch does some internal reorganization to the fields that `listBans()` returns so this is a breaking change. But with this change, you can set additional properties such as a `reason` for a ban message:

``` js
      cabal0.publish({
        type: 'ban/add',
        content: { key: key1, reason: 'spammer' }
      })
```

and then later or on a different synchronized cabal you can read that information back using `banInfo()`:

``` js
          cabal2.moderation.banInfo(bans[0].key, function (err, info) {
            t.error(err)
            t.deepEqual(info.content, {
              key: key1,
              reason: 'spammer'
            })
            t.ok(info.timestamp)
          })
```

This required an upstream change in materialized-group-auth in 1.2.0.