### PR TITLE
add support for mod & admin keys in cabal key uri

### DIFF
--- a/test/mod.js
+++ b/test/mod.js
@@ -9,12 +9,12 @@ test('ban a user by key', function (t) {
   t.plan(7)
 
   var addr = randomBytes(32).toString('hex')
-  var cabal0 = Cabal(ram, 'cabal://' + addr)
+  var cabal0 = Cabal(ram, addr)
   cabal0.ready(function () {
     cabal0.getLocalKey(function (err, key) {
       t.error(err)
-      var cabal1 = Cabal(ram, 'cabal://' + addr, { modKey: key })
-      var cabal2 = Cabal(ram, 'cabal://' + addr, { modKey: key })
+      var cabal1 = Cabal(ram, addr + "?mod=" + key)
+      var cabal2 = Cabal(ram, addr + "?mod=" + key)
       var pending = 3
       cabal1.ready(function () {
         if (--pending === 0) ready(cabal0, cabal1, cabal2)
@@ -98,12 +98,12 @@ test('delegated moderator ban a user by key', function (t) {
   t.plan(16)
 
   var addr = randomBytes(32).toString('hex')
-  var cabal0 = Cabal(ram, 'cabal://' + addr)
+  var cabal0 = Cabal(ram, addr)
   cabal0.ready(function () {
     cabal0.getLocalKey(function (err, key) {
       t.error(err)
-      var cabal1 = Cabal(ram, addr, { modKey: key })
-      var cabal2 = Cabal(ram, addr, { modKey: key })
+      var cabal1 = Cabal(ram, addr + "?mod=" + key)
+      var cabal2 = Cabal(ram, addr + "?mod=" + key)
       var pending = 3
       cabal1.ready(function () {
         if (--pending === 0) ready(cabal0, cabal1, cabal2)
@@ -162,15 +162,15 @@ test('delegated moderator ban a user by key', function (t) {
 test('different mod keys have different views', function (t) {
   t.plan(11)
 
-  var addr = randomBytes(32).toString('hex')
+  var addr = randomBytes(32).toString('hex') 
 
   var cabal0 = Cabal(ram, addr)
   cabal0.ready(function () {
     cabal0.getLocalKey(function (err, key) {
       t.error(err)
-      var cabal1 = Cabal(ram, addr, { modKey: key })
+      var cabal1 = Cabal(ram, addr + "?mod=" + key)
       var cabal2 = Cabal(ram, addr)
-      var cabal3 = Cabal(ram, addr, { modKey: key })
+      var cabal3 = Cabal(ram, addr + "?mod=" + key)
       var pending = 4
       cabal1.ready(function () {
         if (--pending === 0) ready(cabal0, cabal1, cabal2, cabal3)

--- a/views/moderation.js
+++ b/views/moderation.js
@@ -6,8 +6,9 @@ var once = require('once')
 var pump = require('pump')
 var readonly = require('read-only-stream')
 
-module.exports = function (cabal, modKey, db) {
+module.exports = function (cabal, db) {
   var events = new EventEmitter()
+  var modKey = cabal.modKeys[0]
   var auth = mauth(db)
   var queue = []
   var localKey = null


### PR DESCRIPTION
this PR adds basic support for Cabal URIs containing mod & admin keys, e.g. 
`cabal://[0-9A-Fa-f]{64}?mod=<key>` and is related to https://github.com/cabal-club/cabal-client/pull/41