### PR TITLE
listModerationBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,22 @@ The objects in the output have the same form as `listByFlag()`.
 
 Optionally collect results into `cb(err, rows)`.
 
+#### cabal.moderation.listModerationBy(key, cb)
+
+Return a readable object stream of moderation documents authored by `key`.
+
+Each `row` object in the output is a document used for adding, removing, and
+setting flags.
+
+* `row.type` - `"flags/add"`, `"flags/set"`, or `"flags/remove"`
+* `row.content.id` - string key target of this moderation operation
+* `row.content.flags` - array of string flags for this operation
+* `row.content.reason` - array of string flags for this operation
+* `row.content.channel` - string channel name this operation applies to
+* `row.timestamp` - number, when this action was made in milliseconds since 1970
+
+Optionally collect results into `cb(err, rows)`.
+
 #### cabal.moderation.getFlags({ id, channel }, cb)
 
 Get a list of flags set for the user identified by `id` in `channel` as

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ var MEMBERSHIPS = 'j' // j for joined memberships..? :3
 var MESSAGES = 'm'
 var TOPICS = 't'
 var USERS = 'u'
-var MODERATION = 'x'
+var MODERATION_AUTH = 'x'
+var MODERATION_INFO = 'y'
 
 module.exports = Cabal
 module.exports.databaseVersion = DATABASE_VERSION
@@ -93,8 +94,10 @@ function Cabal (storage, key, opts) {
   this.kcore.use('users', createUsersView(
     sublevel(this.db, USERS, { valueEncoding: json })))
   this.kcore.use('moderation', createModerationView(
-    this, sublevel(this.db, MODERATION, { valueEncoding: json }))
-  )
+    this,
+    sublevel(this.db, MODERATION_AUTH, { valueEncoding: json }),
+    sublevel(this.db, MODERATION_INFO, { valueEncoding: json })
+  ))
 
   this.messages = this.kcore.api.messages
   this.channels = this.kcore.api.channels


### PR DESCRIPTION
This secondary index and moderation API is required to make `/inspect` from the [roadmap](https://github.com/cabal-club/commons/issues/10) work.

The patch adds a listModerationBy(key) method which streams primary documents associated with moderation actions for a given user.