### PR TITLE
use regex to capture cabal key instead of URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function Cabal (storage, key, opts) {
     if (Buffer.isBuffer(key)) key = key.toString('hex')
     if (!key.startsWith('cabal://')) key = 'cabal://' + key
     const uri = new URL(key)
-    this.key = sanitizeKey(uri.host)
+    this.key = sanitizeKey(key)
     this.modKeys = uri.searchParams.getAll('mod')
     this.adminKeys = uri.searchParams.getAll('admin')
   }
@@ -255,22 +255,15 @@ function generateKeyHex () {
 }
 
 function isHypercoreKey (key) {
-  if (typeof key === 'string') return /^[0-9a-f]{64}$/.test(key)
+  if (typeof key === 'string') return /^[0-9A-Fa-f]{64}$/.test(key)
   else if (Buffer.isBuffer(key)) return key.length === 32
 }
 
 // Ensures 'key' is a hex string
 function sanitizeKey (key) {
-  // force to hex string
-  if (Buffer.isBuffer(key)) {
-    key = key.toString('hex')
-  }
-
-  // remove any protocol uri prefix
-  if (typeof key === 'string') key = key.replace(/^.*:\/\//, '')
-  else key = undefined
-
-  return key
+  const match = key.match(/^cabal:\/\/([0-9A-Fa-f]{64})/)
+  if (match === null) return undefined
+  return match[1]
 }
 
 function noop () {}


### PR DESCRIPTION
apparently the `new URL()` behaviour is unpredictable. chrome, node, and
firefox all return different values when a cabal key is passed in. 
(`searchParams` always seems to work, however)

for node the cabal key can be found in `uri.host`, in chromium/electron
it's found at `uri.hostname`, for firefox both of those are empty, but
`uri.pathname` gives the cabal key prepended with two slashes (but that
doesn't work in node...)

until [the IANA change](https://github.com/datprotocol/DEPs/issues/66#issuecomment-629016786) lands / has a standardizing effect, let's just use
a regex to capture it.

this patch also changes `isHypercoreKey` to use the same regex as `cabal-client`. 
i dunno if hypercore has a strict lower-case character requirement, however

fixes #88