### PR TITLE
emit flag event when new moderation event indexed

### DIFF
--- a/views/moderation.js
+++ b/views/moderation.js
@@ -14,7 +14,6 @@ var { nextTick } = process
 const MOD = 'm!'
 
 module.exports = function (cabal, authDb, infoDb) {
-    console.error("HERAAAAAAA")
   var events = new EventEmitter()
   var auth = mauth(authDb)
   auth.on('update', function (update) {

--- a/views/moderation.js
+++ b/views/moderation.js
@@ -323,6 +323,7 @@ module.exports = function (cabal, authDb, infoDb) {
         // row has been published by a cabal peer and we're indexing it. 
         // emit event so interfaces may update
         events.emit('flag-event', { 
+          type: row.value.type.replace(/^flags\//, ''),
           by: row.key,
           keyseq: `${row.key}@${row.seq}`, 
           ...row.value.content

--- a/views/moderation.js
+++ b/views/moderation.js
@@ -14,6 +14,7 @@ var { nextTick } = process
 const MOD = 'm!'
 
 module.exports = function (cabal, authDb, infoDb) {
+    console.error("HERAAAAAAA")
   var events = new EventEmitter()
   var auth = mauth(authDb)
   auth.on('update', function (update) {
@@ -320,6 +321,14 @@ module.exports = function (cabal, authDb, infoDb) {
       var id = row.value.content.id
       if (!id) return
       if (/^flags\/(set|add|remove)$/.test(row.value.type)) {
+        // row has been published by a cabal peer and we're indexing it. 
+        // emit event so interfaces may update
+        events.emit('flag-event', { 
+          by: row.key,
+          keyseq: `${row.key}@${row.seq}`, 
+          ...row.value.content
+        })
+
         infoBatch.push({
           type: 'put',
           key: MOD + row.key + '@' + row.seq,


### PR DESCRIPTION
the event we're getting from [materialized-group-auth](https://github.com/substack/materialized-group-auth) is missing a lot of information. 

the event `flag-event` basically reduces the amount of contortions consumers of the moderation api need to do to present actions properly in their interfaces.

the event that is emitted has the following information:
```javascript
{ by:
   '2a0980a46d193418936e13a33c4bd1cb66b745e7c00246b8ee7dbd0b10a1dc8e',
  keyseq:
   '2a0980a46d193418936e13a33c4bd1cb66b745e7c00246b8ee7dbd0b10a1dc8e@12',
  id:
   '9875a983d8a088b9fe62750e86a9d514c47057373fc8827f6096b431927a070c',
  channel: '@',
  type: 'add',
  flags: [ 'hide' ],
  reason: '' 
}
```