### PR TITLE
Document possible flags for `listByFlag`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ banned users.
 #### cabal.moderation.listByFlag({ channel, flag })
 
 Return a readable object stream of records for `channel` that for each user with
-`flag` set. `flag` must be one of: "hidden", "admin", or "mod".
+`flag` set. Flags used by cabal-core include: "hide", "mute", "block", "admin",
+and "mod".
 
 Each `row` object in the output stream has:
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ banned users.
 #### cabal.moderation.listByFlag({ channel, flag })
 
 Return a readable object stream of records for `channel` that for each user with
-`flag` set.
+`flag` set. `flag` must be one of: "hidden", "admin", or "mod".
 
 Each `row` object in the output stream has:
 


### PR DESCRIPTION
Flags are an oft-referred to concept but they aren't enumerated in the documentation. Per a coversation in the default cabal:

```
<kira> right now each user can have flags from set of ["hidden", "admin", "mod"]
<kira> per user perspective
```