### PR TITLE
duplexify must be in object mode for mod streams

### DIFF
--- a/test/mod.js
+++ b/test/mod.js
@@ -150,7 +150,7 @@ test('delegated moderator ban a user by key', function (t) {
 test('different mod keys have different views', function (t) {
   t.plan(11)
 
-  var addr = randomBytes(32).toString('hex') 
+  var addr = randomBytes(32).toString('hex')
 
   var cabal0 = Cabal(ram, addr)
   cabal0.ready(function () {
@@ -495,6 +495,28 @@ test('multiple admins and mods', function (t) {
       ].sort(byKey))
     })
   }
+})
+
+test("can stream mod action", function (t) {
+  t.plan(4)
+  const addr = randomBytes(32).toString('hex')
+  const cabals = [Cabal(ram, addr), Cabal(ram, addr)]
+  getKeys(cabals, function (err, keys) {
+    t.error(err)
+    const key = keys[1]
+    cabals[0].moderation.addFlags({
+      id: key,
+      channel: 'default',
+      flags: ['hide'],
+      reason: 'bad takes. simply the worst'
+    }, function (err) {
+      t.error(err)
+    })
+  })
+  const rs = cabals[0].moderation.list()
+  rs.on('data', function (row) {
+    t.ok(row)
+  })
 })
 
 

--- a/views/moderation.js
+++ b/views/moderation.js
@@ -265,7 +265,7 @@ module.exports = function (cabal, authDb, infoDb) {
       var args = arguments
       var self = this
       if (queue !== null) {
-        var stream = duplexify()
+        var stream = duplexify.obj()
         queue.push(function () {
           stream.setReadable(f.apply(self, args))
         })


### PR DESCRIPTION
This is a WIP PR because I am unfamiliar with the testing suite, so it only fixes my problem presently.

The issue is that if you treat `cabal.moderation.list` as a read stream instead of utilizing its callback, you get this:

```
Uncaught TypeError: The "chunk" argument must be one of type string, Buffer, or Uint8Array. Received type object
      at chunkInvalid (node_modules/readable-stream/lib/_stream_readable.js:313:10)
      at readableAddChunk (node_modules/readable-stream/lib/_stream_readable.js:258:31)
      at Duplexify.Readable.push (node_modules/readable-stream/lib/_stream_readable.js:241:10)
      at Duplexify._forward (node_modules/duplexify/index.js:172:26)
      at Readable.onreadable (node_modules/duplexify/index.js:136:10)
      at emitReadable_ (node_modules/read-only-stream/node_modules/readable-stream/lib/_stream_readable.js:504:10)
      at emitReadable (node_modules/read-only-stream/node_modules/readable-stream/lib/_stream_readable.js:498:62)
      at addChunk (node_modules/read-only-stream/node_modules/readable-stream/lib/_stream_readable.js:298:29)
      at readableAddChunk (node_modules/read-only-stream/node_modules/readable-stream/lib/_stream_readable.js:278:11)
      at Readable.push (node_modules/read-only-stream/node_modules/readable-stream/lib/_stream_readable.js:245:10)
      at Readable.ro._read (node_modules/read-only-stream/index.js:22:16)
      at DestroyableTransform.<anonymous> (node_modules/read-only-stream/index.js:15:16)
      at emitReadable_ (node_modules/readable-stream/lib/_stream_readable.js:538:12)
      at processTicksAndRejections (internal/process/task_queues.js:83:21)
```

Here's an excerpt from the source that triggers the issue:

```
const modStream = cabal.moderation.list()
modStream.on('data', (action) => {
  console.log(action)
})
```

The problem is, apparently, that duplexify must be in object mode to handle the objects produced by the stream. This is accomplished by changing `duplexify()` into `duplexify.obj()`