### PR TITLE
add preferredPort (default 13331) to core opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ var cabal = Cabal(storage, key, { db: level('/tmp/bot.db') })
 
 Other `opts` include:
 
+- `opts.preferredPort`: controls the port cabal listens on. defaults to port `13331`.
 - `opts.modKeys`: an array of keys to be considered moderators from this user's perspective.
 - `opts.adminKeys`: an array of keys to be considered administrators from this user's perspective.
 

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ function Cabal (storage, key, opts) {
   this.maxFeeds = opts.maxFeeds
   this.modKeys = opts.modKeys || []
   this.adminKeys = opts.adminKeys || []
+  this.preferredPort = opts.preferredPort || 13331
 
   if (!key) this.key = generateKeyHex()
   else {

--- a/swarm.js
+++ b/swarm.js
@@ -16,7 +16,8 @@ module.exports = function (cabal, opts, cb) {
 
     const discoveryKey = crypto.discoveryKey(Buffer.from(cabal.key, 'hex'))
 
-    const swarm = hyperswarm()
+    const { preferredPort } = cabal
+    const swarm = hyperswarm({ preferredPort })
     swarm.join(discoveryKey, {
       lookup: true,
       announce: true


### PR DESCRIPTION
add a preferredPort to listen for hyperswarm connections on. the
preferredPort is smart enough that if it is blocked, hyperswarm will try
preferredPort+1, preferredPort+2 before giving up. see the hyperswarm code:
https://github.com/hyperswarm/network/blob/ad41b0c2ac19dbf92865e481282ba6ac6e513d57/index.js#L150-L162

this allows people with highly configured firewalls to port forward a
single port for cabal, which they can themselves configure in their
clients.

fix #98