### PR TITLE
Update core deps & set browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "git+https://github.com/cabal-club/cabal-core.git"
   },
+  "browser": {
+    "hyperswarm": "hyperswarm-web"
+  },
   "keywords": [
     "cabal",
     "decentralized",
@@ -37,10 +40,11 @@
     "dat-encoding": "^5.0.1",
     "debug": "^4.1.1",
     "duplexify": "^4.1.1",
-    "hypercore-crypto": "^1.0.0",
+    "hypercore-crypto": "^2.1.1",
     "hyperswarm": "^2.13.0",
+    "hyperswarm-web": "^2.1.1",
     "inherits": "^2.0.4",
-    "kappa-core": "^6.0.0",
+    "kappa-core": "^7.0.0",
     "kappa-view-level": "^2.0.1",
     "level-mem": "^5.0.1",
     "materialized-group-auth": "^2.1.0",

--- a/swarm.js
+++ b/swarm.js
@@ -17,7 +17,8 @@ module.exports = function (cabal, opts, cb) {
     const discoveryKey = crypto.discoveryKey(Buffer.from(cabal.key, 'hex'))
 
     const { preferredPort } = cabal
-    const swarm = hyperswarm({ preferredPort })
+    opts["preferredPort"] = preferredPort
+    const swarm = hyperswarm(opts)
     swarm.join(discoveryKey, {
       lookup: true,
       announce: true


### PR DESCRIPTION
HAYOO

This PR sets the `browser` field of `package.json` so that we can do some cool hyperswarm-webbing. It also updates a couple of the core dependencies, mimicking the updates needed to make [caballo](https://github.com/cblgh/caballo) work initially. 

With this patch in place, I can successfully browserify cabal-core & query it in the browser (albeit I have only done a couple superficial tests so far, like making sure `core.ready` fires & executing `core.getLocalKey(cb)`. but it is very very promising :3)