### PR TITLE
export Cabal.isHypercoreKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -310,6 +310,7 @@ function isHypercoreKey (key) {
   if (typeof key === 'string') return /^[0-9A-Fa-f]{64}$/.test(key)
   else if (Buffer.isBuffer(key)) return key.length === 32
 }
+module.exports.isHypercoreKey = isHypercoreKey
 
 // Ensures 'key' is a hex string
 function sanitizeKey (key) {


### PR DESCRIPTION
I've been wanting to use this function in cabal-client for a while. In the cabal-client PR https://github.com/cabal-club/cabal-client/pull/76, which is enabling browserifiying the lib, this turned out to be essential (dat-dns would cause browser complaints if we tried to lookup dns records on `https://<cabal-key>`. Thus this PR!

