### PR TITLE
Upgrade sodium-universal for faster install

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "randombytes": "^2.0.6",
     "read-only-stream": "^2.0.0",
     "readable-stream": "^3.4.0",
-    "sodium-universal": "^2.0.0",
+    "sodium-universal": "^3.0.4",
     "strftime": "^0.10.0",
     "subleveldown": "^4.1.0",
     "through2": "^3.0.1",


### PR DESCRIPTION
There was a tiny discrepancy where some parts were using `sodium-native@3.2.1` and others using `sodium-native@2.4.9`, which for some reason had to compile on linux.

Reduces install time from about 1 minute 40 seconds to sub 10 seconds.