### PR TITLE
Use generic encrypted payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Core database, replication, swarming, and chat APIs for cabal.
     - [`cabal.moderation.events.on('update', function (update) {})`](#cabalmoderationeventsonupdate-function-update-)
     - [`cabal.moderation.events.on('skip', function (skip) {})`](#cabalmoderationeventsonskip-function-skip-)
   - [Private Messages](#private-messages)
-    - [`cabal.publishPrivateMessage(text, recipientKey, cb)`](#cabalpublishprivatemessagetext-recipientkey-cb)
+    - [`cabal.publishPrivate(message, recipientKey, cb)`](#cabalpublishprivatemessage-recipientkey-cb)
     - [`cabal.privateMessages.list(cb)`](#cabalprivatemessageslistcb)
     - [`var rs = cabal.privateMessages.read(channel, opts)`](#var-rs--cabalprivatemessagesreadchannel-opts)
     - [`cabal.privateMessages.events.on('message', fn)`](#cabalprivatemessageseventsonmessage-fn)
@@ -276,10 +276,10 @@ record responsible for the state change.
 
 ### Private Messages
 
-#### `cabal.publishPrivateMessage(text, recipientKey, cb)`
+#### `cabal.publishPrivate(message, recipientKey, cb)`
 
-Write the private message string `text` to be encrypted so that only
-`recipientKey` (the public key of its recipient) can read it.
+Write a message `message`, but encrypted so that only `recipientKey` (the
+public key of its recipient) and the sender can read it.
 
 A `timestamp` field is set automatically with the current local system time.
 

--- a/index.js
+++ b/index.js
@@ -117,7 +117,10 @@ function Cabal (storage, key, opts) {
       const done = () => {
         pending--
         // we're done
-        if (pending <= 0) { callQueue.forEach(cb => cb()) }
+        if (pending <= 0) { 
+          callQueue.forEach(cb => cb()) 
+          callQueue = [] // reset call queue
+        }
       }
       pending++
       if (!fn) { return done() }

--- a/index.js
+++ b/index.js
@@ -211,6 +211,9 @@ Cabal.prototype.publishPrivate = function (message, recipientKey, cb) {
 
   this.feed(function (feed) {
     message.timestamp = message.timestamp || timestamp()
+    // attach a bit of metadata signaling that this message is private 
+    // (in a somewhat safe way that doesn't assume any particular pre-existing structure)
+    message.private = true
     const msg = Object.assign({ timestamp: timestamp() }, message)
 
     // Note: we encrypt the message to the recipient, but also to ourselves (so that we can read our part of the convo!)

--- a/test/private.js
+++ b/test/private.js
@@ -35,7 +35,7 @@ test('write a private message & check it\'s not plaintext', function (t) {
 })
 
 test('write a private message & manually decrypt', function (t) {
-  t.plan(11)
+  t.plan(13)
 
   const keypair = crypto.keyPair()
 
@@ -58,6 +58,7 @@ test('write a private message & manually decrypt', function (t) {
       try {
         const message = JSON.parse(plaintext)
         t.same(message.type, 'chat/text', 'type is ok')
+        t.true(message.private, 'field `private` is true')
         t.same(typeof message.content, 'object', 'content is set')
         t.same(message.content.text, 'hello', 'text is ok')
         t.same(message.content.channel, keypair.publicKey.toString('hex'), 'channel field ok')
@@ -73,6 +74,7 @@ test('write a private message & manually decrypt', function (t) {
         try {
           const message = JSON.parse(plaintext)
           t.same(message.type, 'chat/text', 'type is ok')
+          t.true(message.private, 'field `private` is true')
           t.same(typeof message.content, 'object', 'content is set')
           t.same(message.content.text, 'hello', 'text is ok')
           t.same(message.content.channel, keypair.publicKey.toString('hex'), 'channel field ok')
@@ -123,6 +125,7 @@ test('write a private message and read it on the other device', function (t) {
           },
         }
 
+        // c1 -> c2
         c1.publishPrivate(msg, c2._key, (err) => {
           t.error(err)
 

--- a/test/private.js
+++ b/test/private.js
@@ -43,7 +43,7 @@ test('write a private message & manually decrypt', function (t) {
     type: 'chat/text',
     content: {
       text: 'hello',
-      recipients: [keypair.publicKey.toString('hex')]
+      channel: keypair.publicKey.toString('hex')
     },
   }
 
@@ -60,7 +60,7 @@ test('write a private message & manually decrypt', function (t) {
         t.same(message.type, 'chat/text', 'type is ok')
         t.same(typeof message.content, 'object', 'content is set')
         t.same(message.content.text, 'hello', 'text is ok')
-        t.same(message.content.recipients, [keypair.publicKey.toString('hex')], 'recipients field ok')
+        t.same(message.content.channel, keypair.publicKey.toString('hex'), 'channel field ok')
       } catch (err) {
         t.error(err)
       }
@@ -75,7 +75,7 @@ test('write a private message & manually decrypt', function (t) {
           t.same(message.type, 'chat/text', 'type is ok')
           t.same(typeof message.content, 'object', 'content is set')
           t.same(message.content.text, 'hello', 'text is ok')
-          t.same(message.content.recipients, [keypair.publicKey.toString('hex')], 'recipients field ok')
+          t.same(message.content.channel, keypair.publicKey.toString('hex'), 'channel field ok')
         } catch (err) {
           t.error(err)
         }
@@ -119,7 +119,7 @@ test('write a private message and read it on the other device', function (t) {
           type: 'chat/text',
           content: {
             text: 'beeps & boops',
-            recipients: [c2._key.toString('hex')]
+            channel: c2._key.toString('hex')
           },
         }
 

--- a/test/private.js
+++ b/test/private.js
@@ -15,8 +15,7 @@ test('write a private message & check it\'s not plaintext', function (t) {
   const msg = {
     type: 'chat/text',
     content: {
-      text: 'hello',
-      channel: 'general'
+      text: 'hello'
     }
   }
 
@@ -44,7 +43,6 @@ test('write a private message & manually decrypt', function (t) {
     type: 'chat/text',
     content: {
       text: 'hello',
-      channel: 'general',
       recipients: [keypair.publicKey.toString('hex')]
     },
   }
@@ -121,7 +119,6 @@ test('write a private message and read it on the other device', function (t) {
           type: 'chat/text',
           content: {
             text: 'beeps & boops',
-            channel: 'general',
             recipients: [c2._key.toString('hex')]
           },
         }

--- a/views/private-messages.js
+++ b/views/private-messages.js
@@ -50,7 +50,7 @@ module.exports = function (keypair, lvl) {
           return
         }
 
-        if (res.value.type !== 'private/text') return
+        if (!res.value.type.startsWith('chat/')) return
         if (typeof res.value.timestamp !== 'number') return null
         if (!Array.isArray(res.value.content.recipients)) return null
         if (res.value.content.recipients.length <= 0) return null

--- a/views/private-messages.js
+++ b/views/private-messages.js
@@ -18,7 +18,7 @@ module.exports = function (keypair, lvl) {
 
   function getPublicKeyOfOtherParty (msg) {
     const senderHexKey = msg.key
-    const recipientHexKey = msg.value.content.recipients[0]
+    const recipientHexKey = msg.value.content.channel
     if (senderHexKey === keypair.public.toString('hex')) {
       return recipientHexKey
     } else {
@@ -42,8 +42,7 @@ module.exports = function (keypair, lvl) {
 
         if (!res.value.type.startsWith('chat/')) return
         if (typeof res.value.timestamp !== 'number') return null
-        if (!Array.isArray(res.value.content.recipients)) return null
-        if (res.value.content.recipients.length <= 0) return null
+        if (typeof res.value.content.channel !== 'string') return null
         if (typeof res.value.content.text !== 'string') return null
 
         // If the message is from <<THE FUTURE>>, index it at _now_.


### PR DESCRIPTION
Hey @cblgh, this is per our earlier discussion! Here is my new proposal for the structure of private messages & encrypted messages in general:

1. Use a generic encryption format (no `private/chat`, just use `text/chat` so existing logic can be more easily reused).
2. Continue using `'type: "encrypted"` on ciphertext payloads. This means encrypted messages won't affect any existing views, since it's a type unknown to them. Views can opt-in to supporting encrypted messages as needed.
3. I decided against a `cipher_type` key on the ciphertext message, since we didn't have a clear decision on the pros/cons of that. However, we can add later /wo breaking backwards compatibility.

## 1:1 private text message format
It's just the same as regular chat message, but encrypted, and the inner payload has a `recipients` key instead of `channel` key.
```
{
  type: 'chat/text',
  content: {
    text: 'hello',
    recipients: [keypair.publicKey.toString('hex')]
  }
}
```

Does this sound good to you? I kinda suspect that as you're implementing you'll discover any holes in this design. 😈 